### PR TITLE
gh-action to build and deploy kubeflow website

### DIFF
--- a/.github/workflows/hugo_build_deploy_website.yml
+++ b/.github/workflows/hugo_build_deploy_website.yml
@@ -1,0 +1,52 @@
+name: hugo-build-deploy-on-push
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "release-v**"]
+    paths:
+      - website/**
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 0.105.0
+          extended: true
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "VERSION_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/release//;s/-//' | sed 's/main/dev/' | sed 's/v1.7/./')" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Run a multi-line script
+        run: |
+          cd $GITHUB_WORKSPACE/website
+          npm install postcss-cli@10.0.0
+          hugo
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/public
+          destination_dir: ${{ steps.extract_branch.outputs.version_name }}
+          keep_files: true


### PR DESCRIPTION
* This github action is responsible for building the `kubeflow-docs` hugo website and pushing compiled files to `gh-pages` branch.
* This action gets triggered on pushing to the `main` or `release-v*` branch.