### PR TITLE
Update Pipeline manifests

### DIFF
--- a/kubeflow/install.sh
+++ b/kubeflow/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KF_VERSION=v1.8.0-rc.4
+KF_VERSION=v1.8.0-rc.5
 
 helpFunction()
 {
@@ -57,7 +57,7 @@ EOF
 fi
 
 # Install kubeflow
-while ! kustomize build manifests/example  | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build manifests/example  | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 60; done
 
 # Remove kubeflow manifests
 rm -rf manifests
@@ -66,4 +66,5 @@ if [ -n "$use_docker_creds"  ]
 then
     kubectl create secret docker-registry kf-docker-cred --docker-server=$DOCKER_SERVER --docker-username=$DOCKER_USERNAME --docker-password=$DOCKER_PASSWORD --docker-email=$DOCKER_EMAIL -n kubeflow-user-example-com
     kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "kf-docker-cred"}]}' -n kubeflow-user-example-com
+    kubectl patch serviceaccount default-editor -p '{"imagePullSecrets": [{"name": "kf-docker-cred"}]}' -n kubeflow-user-example-com
 fi

--- a/kubeflow/install.sh
+++ b/kubeflow/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KF_VERSION=v1.8.0-rc.5
+KF_VERSION=v1.8.0
 
 helpFunction()
 {

--- a/kubeflow/overlays/pipeline/ntnx/kustomization.yaml
+++ b/kubeflow/overlays/pipeline/ntnx/kustomization.yaml
@@ -27,6 +27,10 @@ configMapGenerator:
   behavior: replace
   files:
   - viewer-pod-template.json
+- name: kubeflow-pipelines-profile-controller-code
+  behavior: replace
+  files:
+  - sync.py
 
 secretGenerator:
 - name: mlpipeline-minio-artifact
@@ -56,3 +60,16 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.insecure
+
+images:
+  - name: gcr.io/ml-pipeline/api-server
+    newName: quay.io/ajaynagar/kubeflow-ntnx/kfp-backend
+    newTag: 2.0.3
+
+  - name: gcr.io/ml-pipeline/frontend
+    newName: quay.io/ajaynagar/kubeflow-ntnx/kfp-frontend
+    newTag: 2.0.3
+
+  - name: gcr.io/ml-pipeline/metadata-writer
+    newName: quay.io/ajaynagar/kubeflow-ntnx/kfp-metadata-writer
+    newTag: 2.0.3

--- a/kubeflow/overlays/pipeline/ntnx/ntnx-config-patch.yaml
+++ b/kubeflow/overlays/pipeline/ntnx/ntnx-config-patch.yaml
@@ -53,4 +53,67 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: objStoreHost
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: bucketName
+            - name: OBJECTSTORECONFIG_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: objStoreRegion
+            - name: OBJECTSTORECONFIG_PORT
+              value: ""
           name: ml-pipeline-api-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-writer
+spec:
+  template:
+    metadata:
+      labels:
+        app: metadata-writer
+    spec:
+      containers:
+      - name: main
+        env:
+        - name: OBJECT_STORE_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: objStoreHost
+        - name: OBJECT_STORE_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: bucketName
+        - name: S3_COMPATIBLE_OBJECT_STORE
+          value: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-pipelines-profile-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: profile-controller
+        env:
+        - name: MINIO_SERVICE_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: objStoreRegion
+        - name: MINIO_SERVICE_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: objStoreHost
+        - name: FRONTEND_TAG
+          value: 2.0.3
+        - name: FRONTEND_IMAGE
+          value: quay.io/ajaynagar/kubeflow-ntnx/kfp-frontend

--- a/kubeflow/overlays/pipeline/ntnx/pipeline-install-config.env
+++ b/kubeflow/overlays/pipeline/ntnx/pipeline-install-config.env
@@ -1,4 +1,4 @@
 bucketName=mlpipeline
 insecure=true
 objStoreHost=YOUR_NTNX_OBJECT_STORE_HOST
-objStoreRegion=ap-northeast-1
+objStoreRegion=us-east-1

--- a/kubeflow/overlays/pipeline/ntnx/sync.py
+++ b/kubeflow/overlays/pipeline/ntnx/sync.py
@@ -407,6 +407,8 @@ def server_factory(visualization_server_image,
                 "data": {
                     "accesskey": minio_access_key,
                     "secretkey": minio_secret_key,
+                    "region": base64.b64encode(bytes(minio_service_region, 'utf-8')).decode('utf-8'),
+                    "endpoint": base64.b64encode(bytes(minio_service_host, 'utf-8')).decode('utf-8'),
                 },
             })
 

--- a/kubeflow/overlays/pipeline/ntnx/sync.py
+++ b/kubeflow/overlays/pipeline/ntnx/sync.py
@@ -1,0 +1,430 @@
+# Copyright 2020-2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import os
+import base64
+
+
+def main():
+    settings = get_settings_from_env()
+    server = server_factory(**settings)
+    server.serve_forever()
+
+
+def get_settings_from_env(controller_port=None,
+                          visualization_server_image=None, frontend_image=None,
+                          visualization_server_tag=None, frontend_tag=None, disable_istio_sidecar=None,
+                          minio_access_key=None, minio_secret_key=None, minio_service_region=None,
+                          minio_service_host=None, kfp_default_pipeline_root=None):
+    """
+    Returns a dict of settings from environment variables relevant to the controller
+
+    Environment settings can be overridden by passing them here as arguments.
+
+    Settings are pulled from the all-caps version of the setting name.  The
+    following defaults are used if those environment variables are not set
+    to enable backwards compatibility with previous versions of this script:
+        visualization_server_image: gcr.io/ml-pipeline/visualization-server
+        visualization_server_tag: value of KFP_VERSION environment variable
+        frontend_image: gcr.io/ml-pipeline/frontend
+        frontend_tag: value of KFP_VERSION environment variable
+        disable_istio_sidecar: Required (no default)
+        minio_access_key: Required (no default)
+        minio_secret_key: Required (no default)
+    """
+    settings = dict()
+    settings["controller_port"] = \
+        controller_port or \
+        os.environ.get("CONTROLLER_PORT", "8080")
+
+    settings["visualization_server_image"] = \
+        visualization_server_image or \
+        os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+
+    settings["frontend_image"] = \
+        frontend_image or \
+        os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+
+    # Look for specific tags for each image first, falling back to
+    # previously used KFP_VERSION environment variable for backwards
+    # compatibility
+    settings["visualization_server_tag"] = \
+        visualization_server_tag or \
+        os.environ.get("VISUALIZATION_SERVER_TAG") or \
+        os.environ["KFP_VERSION"]
+
+    settings["frontend_tag"] = \
+        frontend_tag or \
+        os.environ.get("FRONTEND_TAG") or \
+        os.environ["KFP_VERSION"]
+
+    settings["disable_istio_sidecar"] = \
+        disable_istio_sidecar if disable_istio_sidecar is not None \
+            else os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+
+    settings["minio_access_key"] = \
+        minio_access_key or \
+        base64.b64encode(bytes(os.environ.get("MINIO_ACCESS_KEY"), 'utf-8')).decode('utf-8')
+
+    settings["minio_secret_key"] = \
+        minio_secret_key or \
+        base64.b64encode(bytes(os.environ.get("MINIO_SECRET_KEY"), 'utf-8')).decode('utf-8')
+
+    settings["minio_service_region"] = \
+        minio_service_region or \
+        os.environ.get("MINIO_SERVICE_REGION", "us-east-1")
+
+    settings["minio_service_host"] = \
+        minio_service_host or \
+        os.environ.get("MINIO_SERVICE_HOST", "s3.amazonaws.com")
+
+    # KFP_DEFAULT_PIPELINE_ROOT is optional
+    settings["kfp_default_pipeline_root"] = \
+        kfp_default_pipeline_root or \
+        os.environ.get("KFP_DEFAULT_PIPELINE_ROOT")
+
+    return settings
+
+def server_factory(visualization_server_image,
+                   visualization_server_tag, frontend_image, frontend_tag,
+                   disable_istio_sidecar, minio_access_key,
+                   minio_secret_key, minio_service_region, minio_service_host, kfp_default_pipeline_root=None,
+                   url="", controller_port=8080):
+    """
+    Returns an HTTPServer populated with Handler with customized settings
+    """
+    class Controller(BaseHTTPRequestHandler):
+        def sync(self, parent, children):
+            # parent is a namespace
+            namespace = parent.get("metadata", {}).get("name")
+
+            pipeline_enabled = parent.get("metadata", {}).get(
+                "labels", {}).get("pipelines.kubeflow.org/enabled")
+
+            if pipeline_enabled != "true":
+                return {"status": {}, "children": []}
+
+            desired_configmap_count = 1
+            desired_resources = []
+            if kfp_default_pipeline_root:
+                desired_configmap_count = 2
+                desired_resources += [{
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "kfp-launcher",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "defaultPipelineRoot": kfp_default_pipeline_root,
+                    },
+                }]
+
+
+            # Compute status based on observed state.
+            desired_status = {
+                "kubeflow-pipelines-ready":
+                    len(children["Secret.v1"]) == 1 and
+                    len(children["ConfigMap.v1"]) == desired_configmap_count and
+                    len(children["Deployment.apps/v1"]) == 2 and
+                    len(children["Service.v1"]) == 2 and
+                    len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
+                    len(children["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
+                    "True" or "False"
+            }
+
+            # Generate the desired child object(s).
+            desired_resources += [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "metadata-grpc-configmap",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "METADATA_GRPC_SERVICE_HOST":
+                            "metadata-grpc-service.kubeflow",
+                        "METADATA_GRPC_SERVICE_PORT": "8080",
+                    },
+                },
+                # Visualization server related manifests below
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-visualizationserver"
+                        },
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            },
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-visualizationserver"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "image": f"{visualization_server_image}:{visualization_server_tag}",
+                                    "imagePullPolicy":
+                                        "IfNotPresent",
+                                    "name":
+                                        "ml-pipeline-visualizationserver",
+                                    "ports": [{
+                                        "containerPort": 8888
+                                    }],
+                                    "resources": {
+                                        "requests": {
+                                            "cpu": "50m",
+                                            "memory": "200Mi"
+                                        },
+                                        "limits": {
+                                            "cpu": "500m",
+                                            "memory": "1Gi"
+                                        },
+                                    }
+                                }],
+                                "serviceAccountName":
+                                    "default-editor",
+                            },
+                        },
+                    },
+                },
+                {
+                    "apiVersion": "networking.istio.io/v1alpha3",
+                    "kind": "DestinationRule",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "host": "ml-pipeline-visualizationserver",
+                        "trafficPolicy": {
+                            "tls": {
+                                "mode": "ISTIO_MUTUAL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "security.istio.io/v1beta1",
+                    "kind": "AuthorizationPolicy",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            }
+                        },
+                        "rules": [{
+                            "from": [{
+                                "source": {
+                                    "principals": ["cluster.local/ns/kubeflow/sa/ml-pipeline"]
+                                }
+                            }]
+                        }]
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name": "http",
+                            "port": 8888,
+                            "protocol": "TCP",
+                            "targetPort": 8888,
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-visualizationserver",
+                        },
+                    },
+                },
+                # Artifact fetcher related resources below.
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        },
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-ui-artifact"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-ui-artifact"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "name":
+                                        "ml-pipeline-ui-artifact",
+                                    "image": f"{frontend_image}:{frontend_tag}",
+                                    "imagePullPolicy":
+                                        "IfNotPresent",
+                                    "ports": [{
+                                        "containerPort": 3000
+                                    }],
+                                    "env": [
+                                        {
+                                            "name": "MINIO_ACCESS_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "accesskey",
+                                                    "name": "mlpipeline-minio-artifact"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "MINIO_SECRET_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "secretkey",
+                                                    "name": "mlpipeline-minio-artifact"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "AWS_ACCESS_KEY_ID",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "accesskey",
+                                                    "name": "mlpipeline-minio-artifact"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "AWS_SECRET_ACCESS_KEY",
+                                            "valueFrom": {
+                                                "secretKeyRef": {
+                                                    "key": "secretkey",
+                                                    "name": "mlpipeline-minio-artifact"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "AWS_REGION",
+                                            "value": f"{minio_service_region}"
+                                        },
+                                        {
+                                            "name": "AWS_S3_ENDPOINT",
+                                            "value": f"{minio_service_host}"
+                                        }
+                                    ],
+                                    "resources": {
+                                        "requests": {
+                                            "cpu": "10m",
+                                            "memory": "70Mi"
+                                        },
+                                        "limits": {
+                                            "cpu": "100m",
+                                            "memory": "500Mi"
+                                        },
+                                    }
+                                }],
+                                "serviceAccountName":
+                                    "default-editor"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name":
+                                "http",  # name is required to let istio understand request protocol
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 3000
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    }
+                },
+            ]
+            print('Received request:\n', json.dumps(parent, sort_keys=True))
+            print('Desired resources except secrets:\n', json.dumps(desired_resources, sort_keys=True))
+            # Moved after the print argument because this is sensitive data.
+            desired_resources.append({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": "mlpipeline-minio-artifact",
+                    "namespace": namespace,
+                },
+                "data": {
+                    "accesskey": minio_access_key,
+                    "secretkey": minio_secret_key,
+                },
+            })
+
+            return {"status": desired_status, "children": desired_resources}
+
+        def do_POST(self):
+            # Serve the sync() function as a JSON webhook.
+            observed = json.loads(
+                self.rfile.read(int(self.headers.get("content-length"))))
+            desired = self.sync(observed["parent"], observed["children"])
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+
+    return HTTPServer((url, int(controller_port)), Controller)
+
+
+if __name__ == "__main__":
+    main()

--- a/kubeflow/overlays/pipeline/ntnx/viewer-pod-template.json
+++ b/kubeflow/overlays/pipeline/ntnx/viewer-pod-template.json
@@ -20,6 +20,15 @@
                   "key": "secretkey"
                 }
               }
+            },
+            {
+              "name": "AWS_REGION",
+              "valueFrom": {
+                "configMapKeyRef": {
+                  "name": "pipeline-install-config",
+                  "key": "objStoreRegion"
+                }
+              }
             }
           ]
         }


### PR DESCRIPTION
* Update RC version in the install script.
* Increase waiting time in the installation script.
* Add imagePullSecret to default-editor service account in `kubeflow-user-example-com` namespace.
* `sync.py`: Controller to create pipelines pod when a profile is created. Made the following changes in the default controller:
  - pass region and endpoint to ml-pipeline-ui-artifact deployment (created by profile CRD)
  - add region and endpoint to mlpipeline-minio-artifact secret.