### PR TITLE
Fix KFP Launcher Config Map

### DIFF
--- a/kubeflow/overlays/pipeline/ntnx/kustomization.yaml
+++ b/kubeflow/overlays/pipeline/ntnx/kustomization.yaml
@@ -47,6 +47,9 @@ labels:
   pairs:
     application-crd-id: kubeflow-pipelines
 
+configurations:
+- var-reference.yaml
+
 vars:
 - name: kfp-artifact-storage-endpoint
   objref:
@@ -62,3 +65,17 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.insecure
+- name: kfp-artifact-storage-region
+  objref:
+    kind: ConfigMap
+    name: pipeline-install-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.objStoreRegion
+- name: kfp-artifact-storage-pipeline-root
+  objref:
+    kind: ConfigMap
+    name: pipeline-install-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.defaultPipelineRoot

--- a/kubeflow/overlays/pipeline/ntnx/ntnx-config-patch.yaml
+++ b/kubeflow/overlays/pipeline/ntnx/ntnx-config-patch.yaml
@@ -113,3 +113,28 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: objStoreHost
+        - name: MINIO_SERVICE_INSECURE
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: insecure
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kfp-launcher
+data:
+  defaultPipelineRoot: $(kfp-artifact-storage-pipeline-root)
+  providers: |
+    s3:
+      default:
+        endpoint: $(kfp-artifact-storage-endpoint)
+        disableSSL: $(kfp-artifact-storage-insecure)
+        region: $(kfp-artifact-storage-region)
+        forcePathStyle: true
+        credentials:
+          fromEnv: false
+          secretRef:
+            secretName: mlpipeline-minio-artifact
+            accessKeyKey: accesskey
+            secretKeyKey: secretkey

--- a/kubeflow/overlays/pipeline/ntnx/pipeline-install-config.env
+++ b/kubeflow/overlays/pipeline/ntnx/pipeline-install-config.env
@@ -2,3 +2,4 @@ bucketName=mlpipeline
 insecure=true
 objStoreHost=YOUR_NTNX_OBJECT_STORE_HOST
 objStoreRegion=us-east-1
+defaultPipelineRoot=s3://mlpipeline

--- a/kubeflow/overlays/pipeline/ntnx/var-reference.yaml
+++ b/kubeflow/overlays/pipeline/ntnx/var-reference.yaml
@@ -1,0 +1,3 @@
+varReference:
+- kind: ConfigMap
+  path: data/providers


### PR DESCRIPTION
Changes:
- Update manifests overlay to add correct KFP Launcher configmap to use Nutanix Objects as artifact store for pipelines
- Updated sync.py to create the same config map in all profile namespaces
- ConfigMap structure can be found here: https://www.kubeflow.org/docs/components/pipelines/operator-guides/configure-object-store/#s3-and-s3-compatible-provider

cc: @nagar-ajay 