### PR TITLE
configs for v1.10.1 release website

### DIFF
--- a/.github/workflows/hugo_build_deploy_website.yml
+++ b/.github/workflows/hugo_build_deploy_website.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "VERSION_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/release//;s/-//' | sed 's/main/dev/' | sed 's/v1.8/./')" >> $GITHUB_OUTPUT
+        run: echo "VERSION_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/release//;s/-//' | sed 's/main/dev/' | sed 's/v1.10.1/./')" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Run a multi-line script

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,7 +1,7 @@
 # Base configuration
 ##########################################################
 # Note: Update base URL for older version  when releasing a new version
-baseURL = "https://nutanix.github.io/kubeflow-manifests/dev"
+baseURL = "https://nutanix.github.io/kubeflow-manifests"
 title = "Kubeflow on NKP"
 description = "Open-source machine learning platform running on NKP"
 
@@ -126,18 +126,33 @@ pygmentsStyle = "tango"
 
   # Uncomment this if your GitHub repo does not have "main" as the default branch,
   # or specify a new value if you want to reference another branch in your GitHub links
-  github_branch= "main"
+  github_branch= "release-v1.10.1"
 
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the 
   # current doc set.
-  version = "main"
+  version = "v1.10.1"
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
   url_latest_version = "https://nutanix.github.io/kubeflow-manifests/docs"
 
   # These entries appear in the drop-down menu at the top of the website.
+  [[params.versions]]
+    version = "v1.10.1"
+    githubbranch = "release-v1.10.1"
+    url = "https://nutanix.github.io/kubeflow-manifests/docs"
+
+  [[params.versions]]
+    version = "v1.8"
+    githubbranch = "release-v1.8"
+    url = "https://nutanix.github.io/kubeflow-manifests/v1.8/docs"
+
+  [[params.versions]]
+    version = "v1.7"
+    githubbranch = "release-v1.7"
+    url = "https://nutanix.github.io/kubeflow-manifests/v1.7/docs"
+
   [[params.versions]]
     version = "dev"
     githubbranch = "main"

--- a/website/config.toml
+++ b/website/config.toml
@@ -139,7 +139,7 @@ pygmentsStyle = "tango"
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]
-    version = "v1.10.1"
+    version = "v1.10.1(latest)"
     githubbranch = "release-v1.10.1"
     url = "https://nutanix.github.io/kubeflow-manifests/docs"
 


### PR DESCRIPTION
NOTE: this PR is meant to be raise to v1.10.1, setting this PR to draft until that branch is created

reference commit: https://github.com/nutanix/kubeflow-manifests/commit/2fc42188495ab9a442269975983f4729c6807682 